### PR TITLE
Add KDC for subdomain (sub.test.gokrb5)

### DIFF
--- a/testenv/README.md
+++ b/testenv/README.md
@@ -7,11 +7,11 @@ There are two options to run these services.
 2. As a vagrant VM instances.
 
 ## Docker Containers
-The Docker containers can be run with the commands you see in the ```before_install``` section of the 
-[.travis.yml](https://github.com/jcmturner/gokrb5/blob/master/.travis.yml) file.
+The Docker containers can be run with the commands you see in the ```Start integration test dependencies``` job of the 
+[testing.yml](https://github.com/jcmturner/gokrb5/blob/master/.github/workflows/testing.yml#L60C15-L60C50) file.
 You will need to set the environment variable ```TEST_KDC_ADDR``` to "127.0.0.1" when running the integration tests.
 
-## Vagant VM Instance
+## Vagrant VM Instance
 The Vagrant VM instance has been configured to work with VirtualBox.
 VirtualBox will need to be configured with a host network. In the Vagrantfile configuration the CIDR range for that 
 network is assumed to be 10.80.0.0/16 and the instance will run on 10.80.88.88. If this does not work for your environment you will need to update the 

--- a/testenv/docker/krb5kdc-latest/Dockerfile
+++ b/testenv/docker/krb5kdc-latest/Dockerfile
@@ -5,6 +5,10 @@ EXPOSE 88
 
 ENTRYPOINT ["/usr/local/sbin/krb5kdc", "-n"]
 
+RUN cd /etc/yum.repos.d/ \
+ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+ && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 RUN yum install -y \
   tcpdump krb5-workstation vim \
   ncurses telnet ncurses-devel tcl net-tools \

--- a/testenv/docker/krb5kdc-latest/README.md
+++ b/testenv/docker/krb5kdc-latest/README.md
@@ -1,4 +1,4 @@
-# KDC Intergation Test Instance for TEST.GOKRB5
+# KDC Integration Test Instance for TEST.GOKRB5
 
 DO NOT USE THIS CONTAINER FOR ANY PRODUCTION USE!!!
 

--- a/testenv/docker/krb5kdc-older/Dockerfile
+++ b/testenv/docker/krb5kdc-older/Dockerfile
@@ -5,6 +5,10 @@ EXPOSE 88
 
 ENTRYPOINT ["/usr/local/sbin/krb5kdc", "-n"]
 
+RUN cd /etc/yum.repos.d/ \
+ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+ && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 RUN yum install -y \
   tcpdump krb5-workstation vim \
   ncurses telnet ncurses-devel tcl net-tools \

--- a/testenv/docker/krb5kdc-older/README.md
+++ b/testenv/docker/krb5kdc-older/README.md
@@ -1,4 +1,4 @@
-# KDC Intergation Test Instance for TEST.GOKRB5
+# KDC Integration Test Instance for TEST.GOKRB5
 
 DO NOT USE THIS CONTAINER FOR ANY PRODUCTION USE!!!
 

--- a/testenv/docker/krb5kdc-res/Dockerfile
+++ b/testenv/docker/krb5kdc-res/Dockerfile
@@ -4,6 +4,10 @@ MAINTAINER Jonathan Turner <jt@jtnet.co.uk>
 EXPOSE 88
 ENTRYPOINT ["/usr/sbin/krb5kdc", "-n"]
 
+RUN cd /etc/yum.repos.d/ \
+ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+ && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 RUN yum install -y \
   krb5-server \
   tcpdump krb5-workstation vim \

--- a/testenv/docker/krb5kdc-res/README.md
+++ b/testenv/docker/krb5kdc-res/README.md
@@ -1,4 +1,4 @@
-# KDC Intergation Test Instance for RESDOM.GOKRB5
+# KDC Integration Test Instance for RESDOM.GOKRB5
 
 DO NOT USE THIS CONTAINER FOR ANY PRODUCTION USE!!!
 

--- a/testenv/docker/krb5kdc-shorttickets/Dockerfile
+++ b/testenv/docker/krb5kdc-shorttickets/Dockerfile
@@ -5,6 +5,10 @@ EXPOSE 88
 EXPOSE 464
 ENTRYPOINT ["/opt/krb5/bin/start.sh"]
 
+RUN cd /etc/yum.repos.d/ \
+ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+ && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 RUN yum install -y \
   krb5-server \
   tcpdump krb5-workstation vim \

--- a/testenv/docker/krb5kdc-shorttickets/README.md
+++ b/testenv/docker/krb5kdc-shorttickets/README.md
@@ -1,4 +1,4 @@
-# KDC Intergation Test Instance for TEST.GOKRB5
+# KDC Integration Test Instance for TEST.GOKRB5
 
 DO NOT USE THIS CONTAINER FOR ANY PRODUCTION USE!!!
 

--- a/testenv/docker/krb5kdc-sub/Dockerfile
+++ b/testenv/docker/krb5kdc-sub/Dockerfile
@@ -1,0 +1,23 @@
+FROM centos:latest
+MAINTAINER Jonathan Turner <jt@jtnet.co.uk>
+
+EXPOSE 88
+ENTRYPOINT ["/usr/sbin/krb5kdc", "-n"]
+
+RUN cd /etc/yum.repos.d/ \
+ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+ && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
+RUN yum install -y \
+  krb5-server \
+  tcpdump krb5-workstation vim \
+ && yum update -y && yum clean all
+
+ADD krb5.conf /etc/krb5.conf
+ADD kdc.conf /var/kerberos/krb5kdc/kdc.conf
+ADD kadm5.acl /var/kerberos/krb5kdc/kadm5.acl
+ADD krb5kdc-init.sh /opt/krb5/bin/krb5kdc-init.sh
+RUN mkdir -p /opt/krb5/log && \
+  mkdir -p /var/log/kerberos && \
+  /bin/bash /opt/krb5/bin/krb5kdc-init.sh && \
+  ln -sf /dev/stdout /var/log/krb5kdc.log

--- a/testenv/docker/krb5kdc-sub/README.md
+++ b/testenv/docker/krb5kdc-sub/README.md
@@ -1,0 +1,16 @@
+# KDC Integration Test Instance for SUB.TEST.GOKRB5
+
+DO NOT USE THIS CONTAINER FOR ANY PRODUCTION USE!!!
+
+To run:
+```bash
+docker run -v /etc/localtime:/etc/localtime:ro -p 288:88 -p 188:88/udp --rm --name gokrb5-kdc-sub jcmturner/gokrb5:kdc-sub &
+```
+
+To build:
+```bash
+docker build -t jcmturner/gokrb5:kdc-sub --force-rm=true --rm=true .
+docker push jcmturner/gokrb5:kdc-sub
+```
+
+

--- a/testenv/docker/krb5kdc-sub/kadm5.acl
+++ b/testenv/docker/krb5kdc-sub/kadm5.acl
@@ -1,0 +1,4 @@
+testuser1@SUB.TEST.GOKRB5	*
+*/admin@SUB.TEST.GOKRB5	*
+*/*@SUB.TEST.GOKRB5		i
+*@SUB.TEST.GOKRB5		i

--- a/testenv/docker/krb5kdc-sub/kdc.conf
+++ b/testenv/docker/krb5kdc-sub/kdc.conf
@@ -1,0 +1,15 @@
+[kdcdefaults]
+ kdc_ports = 88
+ kdc_tcp_ports = 88
+
+[realms]
+ SUB.TEST.GOKRB5 = {
+  master_key_type = aes256-cts-hmac-sha1-96
+  max_life = 12h 0m 0s
+  max_renewable_life = 7d 0h 0m 0s
+  acl_file = /var/kerberos/krb5kdc/kadm5.acl
+  dict_file = /usr/share/dict/words
+  admin_keytab = /opt/krb5/data/kadm5.keytab
+  supported_enctypes = aes128-cts-hmac-sha1-96:normal aes256-cts-hmac-sha1-96:normal aes128-cts-hmac-sha256-128:normal aes256-cts-hmac-sha384-192:normal des3-cbc-sha1-kd:normal rc4-hmac:normal
+  default_principal_flags = +renewable
+ }

--- a/testenv/docker/krb5kdc-sub/krb5.conf
+++ b/testenv/docker/krb5kdc-sub/krb5.conf
@@ -1,0 +1,46 @@
+[logging]
+ default = FILE:/var/log/krb5libs.log
+ kdc = FILE:/var/log/krb5kdc.log
+ admin_server = FILE:/var/log/kadmind.log
+
+
+[libdefaults]
+  default_realm = SUB.TEST.GOKRB5
+  dns_lookup_realm = false
+  dns_lookup_kdc = false
+  ticket_lifetime = 24h
+  forwardable = yes
+
+[realms]
+ TEST.GOKRB5 = {
+  kdc = 127.0.0.1:88
+  admin_server = 127.0.0.1:749
+  default_domain = test.gokrb5
+ }
+ SUB.TEST.GOKRB5 = {
+  kdc = 127.0.0.1:288
+  admin_server = 127.0.0.1:749
+  default_domain = sub.test.gokrb5
+ }
+ RESDOM.GOKRB5 = {
+  kdc = 127.0.0.1:188
+  admin_server = 127.0.0.1:749
+  default_domain = resdom.gokrb5
+ }
+
+[domain_realm]
+ .test.gokrb5 = TEST.GOKRB5
+ test.gokrb5 = TEST.GOKRB5
+ .sub.test.gokrb5 = SUB.TEST.GOKRB5
+ sub.test.gokrb5 = SUB.TEST.GOKRB5
+ .resdom.gokrb5 = RESDOM.GOKRB5
+ resdom.gokrb5 = RESDOM.GOKRB5
+
+[appdefaults]
+ pam = {
+   debug = false
+   ticket_lifetime = 36000
+   renew_lifetime = 36000
+   forwardable = true
+   krb4_convert = false
+ }

--- a/testenv/docker/krb5kdc-sub/krb5kdc-init.sh
+++ b/testenv/docker/krb5kdc-sub/krb5kdc-init.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+REALM=SUB.TEST.GOKRB5
+DOMAIN=sub.test.gokrb5
+SERVER_HOST=kdc.sub.test.gokrb5
+ADMIN_USERNAME=adminuser
+HOST_PRINCIPALS="kdc.sub.test.gokrb5 host.sub.test.gokrb5"
+SPNs="HTTP/host.sub.test.gokrb5"
+
+create_entropy() {
+   while true
+   do
+     sleep $(( ( RANDOM % 10 )  + 1 ))
+     echo "Generating Entropy... $RANDOM"
+   done
+}
+
+create_entropy &
+ENTROPY_PID=$!
+
+
+  echo "Kerberos initialisation required. Creating database for ${REALM} ..."
+  echo "This can take a long time if there is little entropy. A process has been started to create some."
+  MASTER_PASSWORD=$(echo $RANDOM$RANDOM$RANDOM | md5sum | awk '{print $1}')
+  /usr/sbin/kdb5_util create -r ${REALM} -s -P ${MASTER_PASSWORD}
+  kill -9 ${ENTROPY_PID}
+  echo "Kerberos database created."
+  /usr/sbin/kadmin.local -q "add_principal -randkey ${ADMIN_USERNAME}/admin"
+  echo "Kerberos admin user created: ${ADMIN_USERNAME} To update password: sudo /usr/sbin/kadmin.local -q \"change_password ${ADMIN_USERNAME}/admin\""
+
+  KEYTAB_DIR="/keytabs"
+  mkdir -p $KEYTAB_DIR
+
+  if [ ! -z "${HOST_PRINCIPALS}" ]; then
+    for host in ${HOST_PRINCIPALS}
+    do
+      /usr/sbin/kadmin.local -q "add_principal -pw hostpasswordvalue -kvno 1 host/$host"
+      echo "Created host principal host/$host"
+    done
+  fi
+
+if [ ! -z "${SPNs}" ]; then
+    for spn in ${SPNs}
+    do
+      /usr/sbin/kadmin.local -q "add_principal -pw spnpasswordvalue -kvno 1 $spn"
+    done
+  fi
+
+  /usr/sbin/kadmin.local -q "add_principal -pw passwordvalue -kvno 1 testuser1"
+  /usr/sbin/kadmin.local -q "add_principal +requires_preauth -pw passwordvalue -kvno 1 testuser2"
+  /usr/sbin/kadmin.local -q "add_principal -pw passwordvalue -kvno 1 testuser3"
+
+  # Set up trust
+  /usr/sbin/kadmin.local -q "add_principal -requires_preauth -pw trustpasswd -kvno 1 krbtgt/SUB.TEST.GOKRB5@TEST.GOKRB5"
+  /usr/sbin/kadmin.local -q "add_principal -requires_preauth -pw trustpasswd -kvno 1 krbtgt/TEST.GOKRB5@SUB.TEST.GOKRB5"
+
+
+  echo "Kerberos initialisation complete"

--- a/testenv/docker/krb5kdc/Dockerfile
+++ b/testenv/docker/krb5kdc/Dockerfile
@@ -5,6 +5,10 @@ EXPOSE 88
 EXPOSE 464
 ENTRYPOINT ["/opt/krb5/bin/start.sh"]
 
+RUN cd /etc/yum.repos.d/ \
+ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+ && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 RUN yum install -y \
   krb5-server \
   tcpdump krb5-workstation vim \

--- a/testenv/docker/krb5kdc/README.md
+++ b/testenv/docker/krb5kdc/README.md
@@ -1,4 +1,4 @@
-# KDC Intergation Test Instance for TEST.GOKRB5
+# KDC Integration Test Instance for TEST.GOKRB5
 
 DO NOT USE THIS CONTAINER FOR ANY PRODUCTION USE!!!
 

--- a/testenv/docker/krb5kdc/krb5kdc-init.sh
+++ b/testenv/docker/krb5kdc/krb5kdc-init.sh
@@ -50,5 +50,7 @@ ENTROPY_PID=$!
   # Set up trust
   /usr/sbin/kadmin.local -q "add_principal -requires_preauth -pw trustpasswd -kvno 1 krbtgt/TEST.GOKRB5@RESDOM.GOKRB5"
   /usr/sbin/kadmin.local -q "add_principal -requires_preauth -pw trustpasswd -kvno 1 krbtgt/RESDOM.GOKRB5@TEST.GOKRB5"
+  /usr/sbin/kadmin.local -q "add_principal -requires_preauth -pw trustpasswd -kvno 1 krbtgt/TEST.GOKRB5@SUB.TEST.GOKRB5"
+  /usr/sbin/kadmin.local -q "add_principal -requires_preauth -pw trustpasswd -kvno 1 krbtgt/SUB.TEST.GOKRB5@TEST.GOKRB5"
 
   echo "Kerberos initialisation complete"

--- a/testenv/docker/krbhttp/Dockerfile
+++ b/testenv/docker/krbhttp/Dockerfile
@@ -7,6 +7,10 @@ ENV KRB5RCACHEDIR=/var/tmp
 ENV KRB5RCACHETYPE=dfl
 ENTRYPOINT ["/usr/sbin/httpd", "-DFOREGROUND"]
 
+RUN cd /etc/yum.repos.d/ \
+ && sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+ && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 RUN yum install -y \
   httpd \
   mod_auth_kerb \

--- a/testenv/docker/krbhttp/README.md
+++ b/testenv/docker/krbhttp/README.md
@@ -1,4 +1,4 @@
-# HTTPD Intergation Test Instance for TEST.GOKRB5
+# HTTPD Integration Test Instance for TEST.GOKRB5
 
 DO NOT USE THIS CONTAINER FOR ANY PRODUCTION USE!!!
 


### PR DESCRIPTION
It adds a new KDC for subdomain (`sub.test.gokrb5`), with established cross-realm trust with the main realm (`test.gokrb5`), so it helps reproducing an scenario as the one described in https://github.com/jcmturner/gokrb5/issues/130, as follows:

```
   test.gokrb5 <--- trust ---> resdom.gokrb5
         /                          \
sub.test.gokrb5           HTTP/host@resdom.gokrb5
       /                             
 testuser1@sub.test.gokrb5    
```  

It also contains a few minor fixes on README.md files.

PS: Note I also added a few comments inline.